### PR TITLE
Allow usage without account binding

### DIFF
--- a/src/common/locales/data/de-DE.json
+++ b/src/common/locales/data/de-DE.json
@@ -185,6 +185,9 @@
   "tool.repository": "Repository",
   "tool.save": "Inhalt speichern",
   "tool.saveButton.noRepository": "Bitte wählen Sie ein Repository aus.",
+  "tool.save.noAccount": "Kein Konto verbunden. Kopieren oder laden Sie den Inhalt stattdessen herunter.",
+  "tool.save.copy": "In die Zwischenablage kopieren",
+  "tool.save.download": "Markdown herunterladen",
   "tool.title": "Titel",
   "tool.title.required": "Titel ist erforderlich",
   "tool.toolExtensions": "Tool-Erweiterung"

--- a/src/common/locales/data/en-US.json
+++ b/src/common/locales/data/en-US.json
@@ -186,6 +186,9 @@
   "tool.repository": "Repository",
   "tool.save": "Save Content",
   "tool.saveButton.noRepository": "Please select a repository",
+  "tool.save.noAccount": "No account connected. Copy or download the content instead.",
+  "tool.save.copy": "Copy to Clipboard",
+  "tool.save.download": "Download Markdown",
   "tool.title": "Title",
   "tool.title.required": "Title is Required",
   "tool.toolExtensions": "Tool Extension"

--- a/src/common/locales/data/ja-JP.json
+++ b/src/common/locales/data/ja-JP.json
@@ -185,6 +185,9 @@
   "tool.repository": "",
   "tool.save": "コンテンツを保存する",
   "tool.saveButton.noRepository": "",
+  "tool.save.noAccount": "アカウントが連携されていません。代わりに内容をコピーするかダウンロードしてください。",
+  "tool.save.copy": "クリップボードにコピー",
+  "tool.save.download": "Markdown をダウンロード",
   "tool.title": "記事タイトル",
   "tool.title.required": "",
   "tool.toolExtensions": ""

--- a/src/common/locales/data/ko-KR.json
+++ b/src/common/locales/data/ko-KR.json
@@ -185,6 +185,9 @@
   "tool.repository": "저장소",
   "tool.save": "컨텐츠 저장",
   "tool.saveButton.noRepository": "저장소를 선택하세요",
+  "tool.save.noAccount": "계정이 연결되지 않았습니다. 대신 내용을 복사하거나 다운로드하세요.",
+  "tool.save.copy": "클립보드에 복사",
+  "tool.save.download": "Markdown 다운로드",
   "tool.title": "컨텐츠 저장",
   "tool.title.required": "제목을 입력해주세요",
   "tool.toolExtensions": "도구 확장"

--- a/src/common/locales/data/ru-RU.json
+++ b/src/common/locales/data/ru-RU.json
@@ -185,6 +185,9 @@
   "tool.repository": "",
   "tool.save": "",
   "tool.saveButton.noRepository": "",
+  "tool.save.noAccount": "Аккаунт не подключён. Вместо этого скопируйте или скачайте содержимое.",
+  "tool.save.copy": "Копировать в буфер",
+  "tool.save.download": "Скачать Markdown",
   "tool.title": "Сохранить контент",
   "tool.title.required": "",
   "tool.toolExtensions": ""

--- a/src/common/locales/data/zh-CN.json
+++ b/src/common/locales/data/zh-CN.json
@@ -202,6 +202,9 @@
   "tool.repository": "知识库",
   "tool.save": "保存内容",
   "tool.saveButton.noRepository": "请选择你要保存的知识库",
+  "tool.save.noAccount": "未绑定账号。可以改为复制内容或下载文件。",
+  "tool.save.copy": "复制到剪贴板",
+  "tool.save.download": "下载 Markdown",
   "tool.title": "笔记标题",
   "tool.title.required": "请输入笔记标题",
   "tool.toolExtensions": "工具扩展"

--- a/src/common/locales/data/zh-TW.json
+++ b/src/common/locales/data/zh-TW.json
@@ -188,6 +188,9 @@
   "tool.repository": "知識庫",
   "tool.save": "保存內容",
   "tool.saveButton.noRepository": "",
+  "tool.save.noAccount": "未綁定帳號。可以改為複製內容或下載檔案。",
+  "tool.save.copy": "複製到剪貼簿",
+  "tool.save.download": "下載 Markdown",
   "tool.title": "筆記標題",
   "tool.title.required": "請輸入筆記標題",
   "tool.toolExtensions": "工具擴展"

--- a/src/pages/preference/index.tsx
+++ b/src/pages/preference/index.tsx
@@ -4,7 +4,7 @@ import Account from './account';
 import ImageHosting from './imageHosting';
 import Extensions from './extensions';
 import { CenterContainer } from 'components/container';
-import { router, connect } from 'dva';
+import { router } from 'dva';
 
 import {
   CloseOutlined,
@@ -14,14 +14,13 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 
-import { Tabs, Badge, message } from 'antd';
+import { Tabs, Badge } from 'antd';
 import { FormattedMessage } from 'react-intl';
 import Base from './base';
-import { DvaRouterProps, GlobalStore } from '@/common/types';
+import { DvaRouterProps } from '@/common/types';
 import Changelog from './changelog';
 import IconFont from '@/components/IconFont';
 import Privacy from './privacy';
-import locale from '@/common/locales';
 import Container from 'typedi';
 import { IConfigService } from '@/service/common/config';
 import { useObserver } from 'mobx-react';
@@ -29,13 +28,6 @@ import { useObserver } from 'mobx-react';
 const { Route } = router;
 
 const TabPane = Tabs.TabPane;
-
-const mapStateToProps = ({ account: { accounts } }: GlobalStore) => {
-  return {
-    accounts,
-  };
-};
-type PageStateProps = ReturnType<typeof mapStateToProps>;
 
 const tabs = [
   {
@@ -78,23 +70,13 @@ const tabs = [
   },
 ];
 
-type PageProps = DvaRouterProps & PageStateProps;
+type PageProps = DvaRouterProps;
 
 const Preference: React.FC<PageProps> = ({
   location: { pathname },
   history: { push },
-  accounts,
 }) => {
   const goHome = () => {
-    if (accounts.length === 0) {
-      message.error(
-        locale.format({
-          id: 'preference.bind.message',
-          defaultMessage: 'You need to bind an account before you can use it.',
-        })
-      );
-      return;
-    }
     push('/');
   };
 
@@ -134,4 +116,4 @@ const Preference: React.FC<PageProps> = ({
   );
 };
 
-export default connect(mapStateToProps)(Preference);
+export default Preference;

--- a/src/pages/tool/Header.tsx
+++ b/src/pages/tool/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo } from 'react';
+import React, { useEffect, useRef, useMemo, useCallback } from 'react';
 import { Form } from '@ant-design/compatible';
 import '@ant-design/compatible/assets/index.less';
 import { Input, Button } from 'antd';
@@ -9,15 +9,21 @@ import styles from './index.less';
 import { useSelector, useDispatch } from 'dva';
 import { GlobalStore, ClipperHeaderForm } from '@/common/types';
 import { updateClipperHeader, asyncCreateDocument } from '@/actions/clipper';
+import { asyncRunExtension } from '@/actions/userPreference';
 import { isEqual } from 'lodash';
 import { ServiceMeta, Repository } from '@/common/backend';
 import classNames from 'classnames';
 import localeService from '@/common/locales';
+import Container from 'typedi';
+import { IExtensionContainer } from '@/service/common/extension';
+import { IExtensionWithId } from '@/extensions/common';
+import { useObserver } from 'mobx-react';
 
 type PageProps = FormComponentProps & {
   pathname: string;
   service: ServiceMeta | null;
   currentRepository?: Repository;
+  hasAccount: boolean;
 };
 
 const ClipperHeader: React.FC<PageProps> = props => {
@@ -27,6 +33,7 @@ const ClipperHeader: React.FC<PageProps> = props => {
     pathname,
     service,
     currentRepository,
+    hasAccount,
   } = props;
   const formValue = getFieldsValue() as ClipperHeaderForm;
   const ref = useRef<ClipperHeaderForm>(formValue);
@@ -37,6 +44,25 @@ const ClipperHeader: React.FC<PageProps> = props => {
     };
   }, isEqual);
   const dispatch = useDispatch();
+
+  const fallbackExtensions = useObserver(() => {
+    const availableExtensions = Container.get(IExtensionContainer).extensions;
+    const findExtension = (id: string) => availableExtensions.find(o => o.id === id);
+    return {
+      copy: findExtension('web-clipper/copyToClipboard'),
+      download: findExtension('web-clipper/download'),
+    } as Record<'copy' | 'download', IExtensionWithId | undefined>;
+  });
+
+  const runFallbackExtension = useCallback(
+    (extension?: IExtensionWithId) => {
+      if (!extension) {
+        return;
+      }
+      dispatch(asyncRunExtension.started({ pathname, extension }));
+    },
+    [dispatch, pathname]
+  );
 
   useEffect(() => {
     if (isEqual(clipperHeaderForm, ref.current)) {
@@ -83,24 +109,58 @@ const ClipperHeader: React.FC<PageProps> = props => {
         })(<Input placeholder="Please Input Title" />)}
       </Form.Item>
       {headerForm}
-      <Button
-        className={styles.saveButton}
-        size="large"
-        type="primary"
-        title={
-          !currentRepository
-            ? localeService.format({
-                id: 'tool.saveButton.noRepository',
-              })
-            : ''
-        }
-        onClick={handleSubmit}
-        loading={loading}
-        disabled={loading || pathname === '/' || !currentRepository}
-        block
-      >
-        <FormattedMessage id="tool.save" defaultMessage="Save Content" />
-      </Button>
+      {hasAccount ? (
+        <Button
+          className={styles.saveButton}
+          size="large"
+          type="primary"
+          title={
+            !currentRepository
+              ? localeService.format({
+                  id: 'tool.saveButton.noRepository',
+                })
+              : ''
+          }
+          onClick={handleSubmit}
+          loading={loading}
+          disabled={loading || pathname === '/' || !currentRepository}
+          block
+        >
+          <FormattedMessage id="tool.save" defaultMessage="Save Content" />
+        </Button>
+      ) : (
+        <div className={styles.saveFallback}>
+          <p className={styles.saveFallbackMessage}>
+            <FormattedMessage
+              id="tool.save.noAccount"
+              defaultMessage="No account connected. Copy or download the content instead."
+            />
+          </p>
+          <Button
+            block
+            className={styles.saveFallbackButton}
+            onClick={() => runFallbackExtension(fallbackExtensions.copy)}
+            disabled={!fallbackExtensions.copy}
+            type="primary"
+          >
+            <FormattedMessage
+              id="tool.save.copy"
+              defaultMessage="Copy to Clipboard"
+            />
+          </Button>
+          <Button
+            block
+            className={styles.saveFallbackButton}
+            onClick={() => runFallbackExtension(fallbackExtensions.download)}
+            disabled={!fallbackExtensions.download}
+          >
+            <FormattedMessage
+              id="tool.save.download"
+              defaultMessage="Download Markdown"
+            />
+          </Button>
+        </div>
+      )}
     </Section>
   );
 };

--- a/src/pages/tool/index.less
+++ b/src/pages/tool/index.less
@@ -12,6 +12,18 @@
     font-size: 16px;
   }
 }
+.saveFallback {
+  margin-top: 8px;
+}
+
+.saveFallbackMessage {
+  margin-bottom: 8px;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.saveFallbackButton + .saveFallbackButton {
+  margin-top: 8px;
+}
 .toolbar {
   font-size: 18px;
   display: flex;

--- a/src/pages/tool/index.tsx
+++ b/src/pages/tool/index.tsx
@@ -97,15 +97,6 @@ const Page = React.memo<PageProps>(
 
     const currentService = currentAccount ? servicesMeta[currentAccount.type] : null;
 
-    useEffect(() => {
-      if (pathname === '/') {
-        if (accounts.length === 0) {
-          dispatch(routerRedux.push('/preference/account'));
-          return;
-        }
-      }
-    }, [accounts.length, dispatch, pathname]);
-
     const onRepositorySelect = useCallback(
       (repositoryId: string) => {
         dispatch(selectRepository({ repositoryId }));
@@ -151,9 +142,10 @@ const Page = React.memo<PageProps>(
           pathname={pathname}
           service={currentService}
           currentRepository={currentRepository}
+          hasAccount={accounts.length > 0}
         />
       );
-    }, [pathname, currentService, currentRepository]);
+    }, [accounts.length, pathname, currentService, currentRepository]);
 
     const overlay = useMemo(() => {
       return (


### PR DESCRIPTION
## Summary
- allow closing the preference modal even when no account is bound and stop redirecting first-time users to the account page
- show copy and download fallback actions on the save panel when no account is connected, wired to the existing tool extensions
- add styling and locale strings for the new fallback actions across supported languages

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ccc1e49718832cbfc2dc0c16f567ca